### PR TITLE
Add health check to docker compose to make sure mysql is up before Rails tries to connect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
   mysql:
+    platform: linux/amd64
     image: mysql:5.7
     restart: always
     environment:
@@ -12,6 +13,11 @@ services:
       - '3306'
 #    extra_hosts:
 #      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u root"]
+      interval: 5s
+      timeout: 10s
+      retries: 3
 
   web:
     build: .
@@ -25,7 +31,8 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
     links:
       - mysql
 


### PR DESCRIPTION
Before, I was getting errors like this:

![image](https://github.com/vulnerable-apps/railsgoat/assets/3422255/94051a37-0806-41c0-b74c-354705d6b515)


Also, I set the `platform` key to amd64; I switched to an M2 Macbook recently, and the mysql image wasn't available for ARM, so I got an error. I was able to overcome it by specifying the platform key to amd64