### PR TITLE
Skip gem install bundler because it is already installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN mkdir /myapp
 WORKDIR /myapp
 ADD Gemfile /myapp/Gemfile
 ADD Gemfile.lock /myapp/Gemfile.lock
-RUN gem install bundler -v 1.17.3
+# RUN gem install bundler -v 1.17.3 --no-document
 RUN bundle install
 ADD . /myapp


### PR DESCRIPTION
I was still getting some installation errors, because (1) `gem install bundler` on Ruby 2.6.5 does not play well on an M2 Mac, (2) the install was taking forever, and (3) bundler 1.17.2 was already installed. I commented out the `gem install bundler` line.